### PR TITLE
Add endpoint to retrieve summary of yesterday's thumbs by agent

### DIFF
--- a/QUERIES.md
+++ b/QUERIES.md
@@ -1,0 +1,27 @@
+## Summary query. Replace the dates as needed.
+
+```
+db.getCollection('thumbs').aggregate([
+    {
+        $match: {
+            createdAt: { $gte : new ISODate("2016-12-12T00:00:00Z"), $lt: ISODate("2016-12-13T00:00:00.000Z")},
+            serviceId: 'your-service-id',
+            uniqueId: { $regex: /^[^_]+$/ }
+        }
+    },
+    {
+        $project: {
+            'agent.name': 1,
+            positive: { $cond: [{$gte: [ '$rating', 0]}, 1, 0]},
+            negative: { $cond: [{$lt: [ '$rating', 0]}, 1, 0]}
+        }
+    },
+    {
+        $group: {
+            _id: '$agent.name',
+            positive: {$sum: '$positive'},
+            negative: {$sum: '$negative'}
+        }
+    }
+])
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ### 1. Install MongoDB
 
+Also, if you'd like a GUI to inspect data with, you can try [RoboMongo](https://robomongo.org/download).
+
 ### 2. Install NodeJS from http://nodejs.org/. Npm should come with it.
 
 ### 3. Install gulp & coffeescript globally
@@ -89,6 +91,18 @@ Sample config:
   ```
 
 ### 10. Enjoy
+
+## Useful info
+
+App runs on `http://localhost:7501`
+
+View list of thumbs at `http://localhost:7501/thumbs/list`
+
+Get a summary of yesterday's thumbs for a service at `http://localhost:7501/thumbs/summary?serviceId=your-service-id`
+
+If you have a db dump from someone, do this to import it:
+
+`mongorestore -d thumbler path/to/thumbs.bson`
 
 ## Hooks
 

--- a/model/thumb.coffee
+++ b/model/thumb.coffee
@@ -22,4 +22,35 @@ ThumbSchema = new mongoose.Schema {
 
 ThumbSchema.plugin paginate
 
+###
+Returns summary of positive/negative thumbs for a particular service, grouped by agent.
+@param {string} serviceId Service ID to match
+@param  {Date} from Datetime from
+@param  {Date} to   Datetime to (exclusive)
+@return {mongoose.Aggregate} Aggregate object you can call exec() on
+###
+ThumbSchema.statics.getServiceSummary = (serviceId, from, to) ->
+  # If you want to put this into CLI, see QUERIES.md for copy-paste
+  return this.aggregate({
+    $match: {
+      createdAt: { $gte : from, $lt: to},
+      serviceId: serviceId,
+      uniqueId: { $regex: /^[^_]+$/ }
+    }
+  },
+  {
+    $project: {
+      'agent.name': 1,
+      positive: { $cond: [{$gte: [ '$rating', 0]}, 1, 0]},
+      negative: { $cond: [{$lt: [ '$rating', 0]}, 1, 0]}
+    }
+  },
+  {
+    $group: {
+      _id: '$agent.name',
+      positive: {$sum: '$positive'},
+      negative: {$sum: '$negative'}
+    }
+  })
+
 module.exports = Thumb = mongoose.model('Thumb', ThumbSchema)

--- a/routes/thumbs.coffee
+++ b/routes/thumbs.coffee
@@ -125,6 +125,14 @@ module.exports = (debug = false) ->
 
   router.use '/list', paginate.middleware(PER_PAGE, PER_PAGE)
 
+  router.get '/summary', (req, res, next) ->
+    today = moment().utc().startOf('day').toDate()
+    yesterday = moment().utc().subtract(1, 'day').startOf('day').toDate()
+    serviceId = req.query.serviceId
+    Thumb
+      .getServiceSummary(serviceId, yesterday, today)
+      .exec((err, result) -> res.json result)
+
   router.get '/list', (req, res, next) ->
 
     page = Math.max(1, req.param('page') or 1)


### PR DESCRIPTION
Closes #25.

Backend will filter the agents; spoke with Margus.

`http://localhost:7501/thumbs/summary?serviceId=desk-toggl`